### PR TITLE
Fix comment referencing release function

### DIFF
--- a/include/videoviewer/videoviewer.hpp
+++ b/include/videoviewer/videoviewer.hpp
@@ -82,7 +82,7 @@ namespace Deltacast
       /*!
       * @brief Release function that destroy opengl window and textures
       *
-      * Ensure that render_loop or render_iteration  returns before calling VV_release function.
+      * Ensure that render_loop or render_iteration  returns before calling the release() function.
       *
       * @returns the status of its execution (true = no error or false = error)
       */


### PR DESCRIPTION
## Summary
- fix comment referencing the `release()` function

## Testing
- `cmake -S . -B build` *(fails: could not find `glfw3`)*

------
https://chatgpt.com/codex/tasks/task_e_6840a75c2664832c894cd054a5c3f48d