### PR TITLE
Fix framebuffer cleanup bug

### DIFF
--- a/src/videoviewer_internal.cpp
+++ b/src/videoviewer_internal.cpp
@@ -108,6 +108,16 @@ void VideoViewer_Internal::delete_vertexes()
    GL_CHECK(glDeleteVertexArrays, 1, &m_conversion_vertex_array);
 }
 
+void VideoViewer_Internal::delete_framebuffers()
+{
+   if (m_conversion_framebuffer != 0)
+   {
+      GL_CHECK(glBindFramebuffer, GL_FRAMEBUFFER, 0);
+      GL_CHECK(glDeleteFramebuffers, 1, &m_conversion_framebuffer);
+      m_conversion_framebuffer = 0;
+   }
+}
+
 
 void VideoViewer_Internal::framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
@@ -310,6 +320,7 @@ bool VideoViewer_Internal::release()
    delete_texture();
 
    delete_vertexes();
+   delete_framebuffers();
 
    m_conversion_shader.reset();
    m_render_shader.reset();


### PR DESCRIPTION
## Summary
- add missing framebuffer deletion helper
- ensure framebuffers are destroyed in `release`

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "glfw3")*

------
https://chatgpt.com/codex/tasks/task_e_683fe41b27ac832cafb97601f321f0f7