### PR TITLE
Add ColorBar unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,5 +13,9 @@ project(
 )
 set(CMAKE_CXX_STANDARD 14)
 
-add_subdirectory ("src")
-add_subdirectory ("sample")
+include(CTest)
+enable_testing()
+
+add_subdirectory("src")
+add_subdirectory("sample")
+add_subdirectory("tests")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.16)
+
+include(FetchContent)
+
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.4.0
+)
+FetchContent_MakeAvailable(Catch2)
+
+add_executable(test_colorbar
+    test_colorbar.cpp
+    ${PROJECT_SOURCE_DIR}/sample/colorbar.cpp
+)
+
+target_include_directories(test_colorbar PRIVATE
+    ${PROJECT_SOURCE_DIR}/sample
+)
+
+target_link_libraries(test_colorbar PRIVATE Catch2::Catch2WithMain)
+
+add_test(NAME test_colorbar COMMAND test_colorbar)

--- a/tests/test_colorbar.cpp
+++ b/tests/test_colorbar.cpp
@@ -1,0 +1,49 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+#include "colorbar.hpp"
+
+using namespace Deltacast;
+
+static uint64_t expected_size(int w, int h, ColorBar::PixelFormat pf)
+{
+    switch (pf)
+    {
+    case ColorBar::PixelFormat::ycbcr_422_8:
+        return static_cast<uint64_t>(w) * h * 2;
+    case ColorBar::PixelFormat::ycbcr_422_10_le_msb:
+        return static_cast<uint64_t>(w) * h * 8 / 3;
+    case ColorBar::PixelFormat::ycbcr_422_10_be:
+        return static_cast<uint64_t>(w) * h * 5 / 2;
+    case ColorBar::PixelFormat::ycbcr_444_8:
+        return static_cast<uint64_t>(w) * h * 3;
+    case ColorBar::PixelFormat::rgb_444_8:
+        return static_cast<uint64_t>(w) * h * 3;
+    case ColorBar::PixelFormat::bgr_444_8_le_msb:
+        return static_cast<uint64_t>(w) * h * 4;
+    case ColorBar::PixelFormat::bgr_444_8:
+        return static_cast<uint64_t>(w) * h * 3;
+    default:
+        return 0;
+    }
+}
+
+TEST_CASE("ColorBar datasize matches expected", "[ColorBar]")
+{
+    const int width = 12;
+    const int height = 8;
+    const ColorBar::PixelFormat formats[] = {
+        ColorBar::PixelFormat::ycbcr_422_8,
+        ColorBar::PixelFormat::ycbcr_422_10_le_msb,
+        ColorBar::PixelFormat::ycbcr_422_10_be,
+        ColorBar::PixelFormat::ycbcr_444_8,
+        ColorBar::PixelFormat::rgb_444_8,
+        ColorBar::PixelFormat::bgr_444_8_le_msb,
+        ColorBar::PixelFormat::bgr_444_8
+    };
+
+    for (auto pf : formats)
+    {
+        ColorBar bar(width, height, pf);
+        REQUIRE(bar.get_datasize() == expected_size(width, height, pf));
+    }
+}


### PR DESCRIPTION
## Summary
- enable CTest and add tests target
- add FetchContent for Catch2
- test ColorBar datasize logic

## Testing
- `cmake -S . -B build-tests -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build-tests`
- `ctest --test-dir build-tests -V`


------
https://chatgpt.com/codex/tasks/task_e_6840a7a4a98c832c8e32f2d5265901de