### PR TITLE
Fix header path in installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.2
+## Unreleased
 
 ### Fixed
 - Install videoviewer.hpp instead of videoviewer.h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.2
+
+### Fixed
+- Install videoviewer.hpp instead of videoviewer.h
+
 ## 1.4.1
 
 ### Fixed

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 
 set_target_properties(video-viewer PROPERTIES CXX_EXTENSIONS OFF)
 
-set_target_properties(video-viewer PROPERTIES PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/include/videoviewer/videoviewer.h)
+set_target_properties(video-viewer PROPERTIES PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/include/videoviewer/videoviewer.hpp)
 set_target_properties(video-viewer PROPERTIES DEBUG_POSTFIX d)
 
 install(TARGETS video-viewer DESTINATION "."


### PR DESCRIPTION
## Summary
- install the correct header by using `videoviewer.hpp` in `src/CMakeLists.txt`

## Testing
- `cmake --preset conan-release`
- `cmake --build --preset conan-release`
- `cmake --install build/Release --prefix /tmp/vvinstall`

------
https://chatgpt.com/codex/tasks/task_e_6840ab63be78832cbcdaad68c8f07add