### PR TITLE
Fix framebuffer status check timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.2
+## Unreleased
 
 ### Fixed
 - Check framebuffer completeness before unbinding in `create_framebuffers()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.2
+
+### Fixed
+- Check framebuffer completeness before unbinding in `create_framebuffers()`
+
 ## 1.4.1
 
 ### Fixed

--- a/src/videoviewer_internal.cpp
+++ b/src/videoviewer_internal.cpp
@@ -362,13 +362,15 @@ void VideoViewer_Internal::create_framebuffers()
    GL_CHECK(glGenFramebuffers, 1, &m_conversion_framebuffer);
    GL_CHECK(glBindFramebuffer, GL_FRAMEBUFFER, m_conversion_framebuffer);
    GL_CHECK(glFramebufferTexture2D, GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture_to_render, 0);
-   GL_CHECK(glBindFramebuffer, GL_FRAMEBUFFER, 0);
 
-   if(GL_CHECK_OUTPUT(glCheckFramebufferStatus, GL_FRAMEBUFFER).value != GL_FRAMEBUFFER_COMPLETE)
+   GLenum status = GL_CHECK_OUTPUT(glCheckFramebufferStatus, GL_FRAMEBUFFER).value;
+   if(status != GL_FRAMEBUFFER_COMPLETE)
    {
       std::cout << "Framebuffer not complete" << std::endl;
       throw std::runtime_error("Framebuffer not complete");
    }
+
+   GL_CHECK(glBindFramebuffer, GL_FRAMEBUFFER, 0);
 }
 
 void VideoViewer_Internal::create_textures()


### PR DESCRIPTION
## Summary
- check framebuffer status before unbinding

## Testing
- `cmake --build --preset conan-release`
- `ctest --preset conan-release`

------
https://chatgpt.com/codex/tasks/task_e_6840aaf5aba4832c8b80ca2f18755984