### PR TITLE
Fix MacOS spelling in comments

### DIFF
--- a/include/videoviewer/videoviewer.hpp
+++ b/include/videoviewer/videoviewer.hpp
@@ -100,7 +100,7 @@ namespace Deltacast
       /*!
       * @brief Render iteration that renders textures in the opengl context
       *
-      * Note: render_loop function should be preferred to this function but, in the case of the rendering must be done in the main thread (i.e. on Macos), this function can be used to make a custom loop
+      * Note: render_loop function should be preferred to this function but, in the case of the rendering must be done in the main thread (i.e. on macOS), this function can be used to make a custom loop
       * 
       * Limitation: this function should be called in the same thread that calls init to allow window events to be processed
       */

--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -77,7 +77,7 @@ void pattern_thread(Deltacast::VideoViewer& viewer, int width, int height, Delta
    synchronisation_cv.notify_one();
 }
 
-//Limitation: For Macos, the rendering is done in the main thread
+//Limitation: For macOS, the rendering is done in the main thread
 #if !defined(__APPLE__)
 //This function is called inside a new thread that will be used to render the video
 void render_video(Deltacast::VideoViewer& viewer,int window_width, int window_height, const char* window_title, int texture_width, int texture_height, Deltacast::VideoViewer::InputFormat input_format, int frame_rate_in_ms, std::atomic<bool>& stop, std::condition_variable& synchronisation_cv, std::mutex& synchronisation_mutex)


### PR DESCRIPTION
## Summary
- correct `Macos` to `macOS` in comments

## Testing
- `ctest --test-dir build/Release -j$(nproc) --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6841f2e40b34832c993a942c5a760f13